### PR TITLE
refactor: bump Spring(6) and Java(17) version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.lindar</groupId>
     <artifactId>id3global-client</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>id3global Client</name>
@@ -59,17 +59,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>2.3.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.ws</groupId>
-            <artifactId>jaxws-ri</artifactId>
-            <version>2.3.3</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
@@ -118,14 +107,14 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
-                <version>0.14.0</version>
+                <groupId>org.jvnet.jaxb</groupId>
+                <artifactId>jaxb-maven-plugin</artifactId>
+                <version>4.0.0</version>
                 <dependencies>
                     <dependency>
-                        <groupId>org.glassfish.jaxb</groupId>
-                        <artifactId>jaxb-runtime</artifactId>
-                        <version>2.3.3</version>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-xjc</artifactId>
+                        <version>4.0.4</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -150,12 +139,13 @@
                                 <arg>-Xxew</arg>
                                 <arg>-Xxew:instantiate lazy</arg>
                                 <arg>-extension</arg>
+                                <arg>-wsdl</arg>
                             </args>
                             <plugins>
                                 <plugin>
                                     <groupId>com.github.jaxb-xew-plugin</groupId>
                                     <artifactId>jaxb-xew-plugin</artifactId>
-                                    <version>1.9</version>
+                                    <version>2.1</version>
                                 </plugin>
                             </plugins>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -38,29 +38,37 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-ws-core</artifactId>
-            <version>3.1.1</version>
+            <version>4.0.8</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.30</version>
             <scope>compile</scope>
         </dependency>
-
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-ri</artifactId>
+            <version>2.3.3</version>
+            <type>pom</type>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -76,8 +84,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -113,6 +121,13 @@
                 <groupId>org.jvnet.jaxb2.maven2</groupId>
                 <artifactId>maven-jaxb2-plugin</artifactId>
                 <version>0.14.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.glassfish.jaxb</groupId>
+                        <artifactId>jaxb-runtime</artifactId>
+                        <version>2.3.3</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.lindar</groupId>
     <artifactId>id3global-client</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>id3global Client</name>

--- a/src/main/java/com/lindar/id3global/adapter/InstantDateTimeAdapter.java
+++ b/src/main/java/com/lindar/id3global/adapter/InstantDateTimeAdapter.java
@@ -1,6 +1,6 @@
 package com.lindar.id3global.adapter;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 import java.time.*;
 
 public class InstantDateTimeAdapter extends XmlAdapter<String, Instant> {

--- a/src/main/java/com/lindar/id3global/adapter/LocalDateAdapter.java
+++ b/src/main/java/com/lindar/id3global/adapter/LocalDateAdapter.java
@@ -1,6 +1,6 @@
 package com.lindar.id3global.adapter;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 import java.time.LocalDate;
 
 public class LocalDateAdapter extends XmlAdapter<String,LocalDate> {

--- a/src/main/java/com/lindar/id3global/adapter/LocalDateTimeAdapter.java
+++ b/src/main/java/com/lindar/id3global/adapter/LocalDateTimeAdapter.java
@@ -1,7 +1,7 @@
 package com.lindar.id3global.adapter;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import java.time.LocalDate;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+
 import java.time.LocalDateTime;
 
 public class LocalDateTimeAdapter extends XmlAdapter<String,LocalDateTime> {

--- a/src/main/java/com/lindar/id3global/support/WSSESecurityHeaderRequestWebServiceMessageCallback.java
+++ b/src/main/java/com/lindar/id3global/support/WSSESecurityHeaderRequestWebServiceMessageCallback.java
@@ -6,7 +6,7 @@ import org.springframework.ws.WebServiceMessage;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
 import org.springframework.ws.soap.saaj.SaajSoapMessage;
 
-import javax.xml.soap.*;
+import jakarta.xml.soap.*;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
 

--- a/src/main/resources/bindings.xml
+++ b/src/main/resources/bindings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jaxb:bindings
-		xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" xmlns:xs="http://www.w3.org/2001/XMLSchema"
 		xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
-		version="2.1">
+		xsi:schemaLocation="https://jakarta.ee/xml/ns/jaxb https://jakarta.ee/xml/ns/jaxb/bindingschema_3_0.xsd"
+		version="3.0">
 
         	 <jaxb:globalBindings
 					 generateElementProperty="false"


### PR DESCRIPTION
## Overview
Due to the fact that the library was built with Java 1.8, it is challenging to integrate it into modern projects.

## Changes
- Upgraded Java to v17
- Upgraded Spring dependencies to v6